### PR TITLE
Add support for Markdown rendering Homepage content

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ class="mb-3"
 style="" >}}
 ```
 
+## Rendering Markdown in the root path
+If content for the root home page needs to be rendered from a markdown, create a file named `homepage.md` in the Contents directory with the following content. Anything below the header gets rendered as markdown in the homepage:
+
+```
++++
+type = "homepage"
++++
+Content in *Markdown*
+```
+
 ## Getting Help
 
 If you run into an issue that isn't answered by this documentation or the [`exampleSite`](https://github.com/zwbetz-gh/vanilla-bootstrap-hugo-theme/tree/master/exampleSite), then head over to the [Hugo discussion forum](https://discourse.gohugo.io/). The folks there are helpful and friendly. **Before** asking your question, be sure to read the [requesting help guidelines](https://discourse.gohugo.io/t/requesting-help/9132). Feel free to tag me in your question, my username there is [`@zwbetz`](https://discourse.gohugo.io/u/zwbetz/summary).

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,18 @@
 {{ define "main" }}
 
+{{ range .Data.Pages }}
+    {{if eq .Type "homepage" }}
+        {{.HomepageMarkdownContent}}
+    {{end}}
+{{ end }}
+
 <div id="home-jumbotron" class="jumbotron text-center">
   <h1>{{ .Site.Title }}</h1>
-  <p class="font-125">{{ .Site.Params.homeText | markdownify }}</p>
+  {{if isset .HomepageMarkdownContent}}
+    <p class="font-125">{{ .HomepageMarkdownContent | markdownify }}</p>
+  {{else}}
+    <p class="font-125">{{ .Site.Params.homeText | markdownify }}</p>
+  {{end}}
 </div>
 
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,10 +7,10 @@
 {{ end }}
 
 <div id="home-jumbotron" class="jumbotron text-center">
-  <h1>{{ .Site.Title }}</h1>
   {{if isset .HomepageMarkdownContent}}
     <p class="font-125">{{ .HomepageMarkdownContent | markdownify }}</p>
   {{else}}
+    <h1>{{ .Site.Title }}</h1>
     <p class="font-125">{{ .Site.Params.homeText | markdownify }}</p>
   {{end}}
 </div>


### PR DESCRIPTION
This PR adds support to render the homepage contents from a markdown file called `homepage.md` if it is present. Currently, the only way the homepage contents are set from homeText parameter set in the config.toml file. With this new addition, whatever is written in the `homepage.md` gets rendered easily.

I found this by using the solution posted in the main Hugo repo: https://github.com/gohugoio/hugo/issues/330#issuecomment-67890306