### PR TITLE
Identification of current navigation menu item based on page identifier

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -6,6 +6,7 @@
     {{ $active := "" }}
     {{ if eq $showActiveNav true }}
       {{ $isMenu := or ($currentPage.IsMenuCurrent "nav" .) ($currentPage.HasMenuCurrent "nav" .) }}
+      {{ $isMenu = or $isMenu (eq $currentPage.Params.identifier .Identifier) }}
       {{ $isMenu = or $isMenu (eq $currentPage.Title .Name) }}
       {{ $isMenu = or $isMenu (and (eq .Name "Blog") (eq $currentPage.Section "post")) }}
       {{ $isMenu = or $isMenu (and (eq .Name "Tags") (eq $currentPage.Section "tags")) }}


### PR DESCRIPTION

Allow navigation based on page identifier and identifier of nav menu item

Currently, the `isMenu` variable in layouts/partials/nav.html is calculated based on the name of the nav menu item and the title of the current page (amongst other things). If the page title differs from the menu item's name, the current page is not highlighted in the navigation bar. I therefore added an `isMenu` check based on the identifier (parameter) of a page:

`{{ $isMenu = or $isMenu (eq $currentPage.Params.identifier .Identifier) }}`

The identifier is used like this:

In `config.toml` an identifier is used for the nav menu items:

```
  [[menu.nav]]
    identifier = "courses"
    name = "Courses"
    pre = "smile"
    url = "/courses"
    weight = 2
```

In a page, an identifier is used in the page's parameters:

```
---
title: "Courses/Lehrveranstaltungen"
identifier: "courses"
date: 2019-10-24T13:05:34+02:00
draft: false
---
```